### PR TITLE
Show why  --file wouldn't work

### DIFF
--- a/test/prepare.js
+++ b/test/prepare.js
@@ -1,7 +1,12 @@
 'use strict';
 
+const assert = require('assert')
+
 before(function() {
   return new Promise(resolve => {
+    assert.ok(!global.test1touched, "test1 shouldn't be loaded yet");
+    assert.ok(!global.test2touched, "test2 shouldn't be loaded yet");
+
     console.log('Preparing ...');
     setTimeout(() => {
       console.log('... prepared!');
@@ -11,6 +16,9 @@ before(function() {
 });
 
 after(function() {
+  assert.ok(global.test1touched, "test1 shouldn be loaded and tested by now");
+  assert.ok(global.test2touched, "test2 shouldn be loaded and tested by now");
+
   return new Promise(resolve => {
     console.log('Unpreparing ...');
     setTimeout(() => {

--- a/test/test1.spec.js
+++ b/test/test1.spec.js
@@ -3,6 +3,8 @@
 const assert = require('assert');
 const path = require('path');
 
+global.test1touched = true;
+
 describe('mocha-test', function() {
   it('prepare.js must be loaded by now', function() {
     // prepare.js has been loaded

--- a/test/test2.spec.js
+++ b/test/test2.spec.js
@@ -3,6 +3,8 @@
 const assert = require('assert');
 const path = require('path');
 
+global.test2touched = true;
+
 describe('mocha-test 2', function() {
   it('prepare.js must be loaded by now', function() {
     // prepare.js has been loaded


### PR DESCRIPTION
I modified a bit to your test specs to show why --file wouldn't work.

The problem I am trying to address is described [here](https://www.npmjs.com/package/mocha-prepare).

Many people including me would like to have a way to asynchronously initialize modules to be tested **before the test specs are loaded**.